### PR TITLE
Feature/#62 생성한 지 24시간이 지난 집중 세션 방 삭제 로직 최적화

### DIFF
--- a/src/main/java/com/example/mutsideout_mju/repository/RoomRepository.java
+++ b/src/main/java/com/example/mutsideout_mju/repository/RoomRepository.java
@@ -2,11 +2,16 @@ package com.example.mutsideout_mju.repository;
 
 import com.example.mutsideout_mju.entity.Planner;
 import com.example.mutsideout_mju.entity.Room;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface RoomRepository extends JpaRepository<Room, UUID> {
     Optional<Room> findByUserIdAndId(UUID userId, UUID roomId);
+
+    @Transactional
+    void deleteByCreatedAtBefore(LocalDateTime dateTime);
 }


### PR DESCRIPTION
## Description
- 생성한 지 24시간이 지난 집중 세션 방 삭제 로직 최적화
- 현재는 집중 세션 방 전체 조회 시 24시간이 지난 방들을 findAll()로 필터링하여 전체 삭제하는 로직인데, 전체 조회 시 이미지 분석 로직(썸네일)도 추가될 것이기에 계속된 부하가 있을 것 같아 분리해야함.
## Changes
- [x] RoomRepository
- [x] RoomService
## Additional context
- @Scheduled 어노테이션을 이용해 매시간별 삭제 로직 진행, 24시간 지난 방 삭제 요청을 분산처리하려한다.

Closes #62 