### PR TITLE
Feature/#79 감정일기 수정 기능 개선

### DIFF
--- a/src/main/java/com/example/mutsideout_mju/controller/DiaryController.java
+++ b/src/main/java/com/example/mutsideout_mju/controller/DiaryController.java
@@ -56,8 +56,9 @@ public class DiaryController {
     public ResponseEntity<ResponseDto<Void>> updateDiaryById(@AuthenticatedUser User user,
                                                              @PathVariable UUID diaryId,
                                                              @RequestPart("data") @Valid UpdateDiaryDto updateDiaryDto,
-                                                             @RequestPart(value = "image", required = false) List<MultipartFile> images) throws IOException {
-        diaryService.updateDiaryById(user, diaryId, updateDiaryDto, images);
+                                                             @RequestPart(value = "image", required = false) List<MultipartFile> images,
+                                                             @RequestPart(value = "deleteImageIds", required = false) List<UUID> imageIdsToDelete) throws IOException {
+        diaryService.updateDiaryById(user, diaryId, updateDiaryDto, images, imageIdsToDelete);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "감정일기가 정상적으로 수정되었습니다."), HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/mutsideout_mju/dto/response/diary/DiaryResponseData.java
+++ b/src/main/java/com/example/mutsideout_mju/dto/response/diary/DiaryResponseData.java
@@ -1,5 +1,6 @@
 package com.example.mutsideout_mju.dto.response.diary;
 
+import com.example.mutsideout_mju.dto.response.image.ImageData;
 import com.example.mutsideout_mju.entity.Diary;
 import com.example.mutsideout_mju.entity.ImageFile;
 import lombok.Builder;
@@ -16,19 +17,19 @@ public class DiaryResponseData {
     private UUID id;
     private String title;
     private String content;
-    private List<String> imageUrls;
+    private List<ImageData> imageDataList;
     private String createdAt;
 
     public static DiaryResponseData from(Diary diary) {
-        List<String> images = diary.getImageFiles().stream()
-                .map(ImageFile::getImageUrl)
+        List<ImageData> images = diary.getImageFiles().stream()
+                .map(imageFile -> new ImageData(imageFile.getId(),imageFile.getImageUrl()))
                 .collect(Collectors.toList());
 
         return DiaryResponseData.builder()
                 .id(diary.getId())
                 .title(diary.getTitle())
                 .content(diary.getContent())
-                .imageUrls(images)
+                .imageDataList(images)
                 .createdAt(diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .build();
     }

--- a/src/main/java/com/example/mutsideout_mju/dto/response/image/ImageData.java
+++ b/src/main/java/com/example/mutsideout_mju/dto/response/image/ImageData.java
@@ -1,0 +1,13 @@
+package com.example.mutsideout_mju.dto.response.image;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class ImageData {
+    private UUID imageId;
+    private String imageUrl;
+}

--- a/src/main/java/com/example/mutsideout_mju/service/DiaryService.java
+++ b/src/main/java/com/example/mutsideout_mju/service/DiaryService.java
@@ -87,21 +87,23 @@ public class DiaryService {
      * 감정일기 수정
      */
     @Transactional
-    public void updateDiaryById(User user, UUID diaryId, UpdateDiaryDto updateDiaryDto, List<MultipartFile> images) throws IOException {
+    public void updateDiaryById(User user, UUID diaryId,
+                                UpdateDiaryDto updateDiaryDto,
+                                List<MultipartFile> images,
+                                List<UUID> imageIdsToDelete) throws IOException {
         Diary newDiary = findDiary(user.getId(), diaryId);
+        // 이미지 삭제
+        if (imageIdsToDelete != null && !imageIdsToDelete.isEmpty()) {
+            imageService.deleteImagesByImageIds(imageIdsToDelete);
+        }
 
-        try {
-            if (images != null && !images.isEmpty()) {
-                imageService.deleteImages(newDiary);
-                imageService.uploadImages(user, newDiary, images);
-            }
-        } catch (MultipartException e) {
-            throw new MultipartException(e.getMessage());
+        // 이미지 업로드
+        if (images != null && !images.isEmpty()) {
+            imageService.uploadImages(user, newDiary, images);
         }
 
         newDiary.setTitle(updateDiaryDto.getTitle())
                 .setContent(updateDiaryDto.getContent());
-
         diaryRepository.save(newDiary);
     }
 

--- a/src/main/java/com/example/mutsideout_mju/service/ImageFileService.java
+++ b/src/main/java/com/example/mutsideout_mju/service/ImageFileService.java
@@ -13,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -47,6 +48,18 @@ public class ImageFileService {
             filesToDelete.forEach(img -> s3Service.deleteImage(img.getImageUrl()));
             imageFileRepository.deleteAll(filesToDelete);
             diary.getImageFiles().clear();
+        }
+    }
+
+    /**
+     * 특정 ID의 이미지 삭제
+     */
+    @Transactional
+    public void deleteImagesByImageIds(List<UUID> imageIds) {
+        if (imageIds != null && !imageIds.isEmpty()) {
+            List<ImageFile> filesToDelete = imageFileRepository.findAllById(imageIds);
+            filesToDelete.forEach(img -> s3Service.deleteImage(img.getImageUrl()));
+            imageFileRepository.deleteAllInBatch(filesToDelete);
         }
     }
 }


### PR DESCRIPTION
## Description
- 감정일기 수정 기능 개선
- 감정일기 수정 시 업로드 되어있던 모든 이미지들을 삭제하고 다시 업로드해야하는 로직이었음.
- 업로드할 이미지, 삭제할 이미지 ID 리스트를 받아 삭제와 업로드 로직 분리
## Changes
- [x] ImageFileService
- [x] DiaryService
- [x] DiaryController
## Additional context

Closes #79 